### PR TITLE
Update Vercel config to replace depricated build base

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,7 +7,7 @@
   "builds": [
     {
       "src": "api/**/*.go",
-      "use": "@now/go"
+      "use": "@vercel/go"
     }
   ],
   "routes": [


### PR DESCRIPTION
Hiya @someshkar 
Love your project :)

I just went to try it out on Vercel, and noticed that build fails because the base in the now.json is still using the older `@now/go` image, which is deprecated.

Here's a quick PR which updates that to the newer `@vercel/go` :)
I've tested it out by deploying a demo instance to `https://whois-api-zeta.vercel.app/` and it seems to work all great.
